### PR TITLE
prepare for v0.0.1 release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "shadowsocks-config",
+  "version": "0.0.1",
   "homepage": "https://github.com/uProxy/ShadowsocksConfig",
   "authors": [
     "jab <jab@users.noreply.github.com>"


### PR DESCRIPTION
Since this is the initial implementation, the entire tree can be reviewed at https://github.com/uProxy/ShadowsocksConfig/tree/dist-0.0.1 instead of in this tiny change set. 

Big thanks to @gronke and @fortuna for the terrific suggestions so far. 