### PR TITLE
do formatting and linting like the other repos

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+ColumnLimit: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,30 +13,17 @@
 # limitations under the License.
 
 language: node_js
+
 node_js:
   - 8
-env:
-  global:
-    - YARN_VERSION="1.2.1"
-    - YARN_CACHE_FOLDER="${HOME}/.yarn-cache"
-    - secure: "ZpBgEPY361Hx60ovvPizm7EBtmoblkVM3uUAP8bHlQ8VC33fuSNhbm/MP6iqiweqOQk2qvuLdj0RphX6GhrB76bYGUw+NrxFTn2NhC/+6qUYBaaNgytNllBClcxN11WxwVS9bUOrXtrSqtCL4mv5WUaZcHwZllfXqGlLOdmUE3KYsGoGerMRSMajIleMDYerrbd2SuqFThyq6/zRux/arqs3Vz/iRSZrCHaoU4Ff8TerIxuz+4YnUtvQHNVe6hZVX8254cPWLebNJxAQgkfMbdVz+pc70+i6R9iMj85XKnR3R+QYh3pg3jFtsKTKdyyKY/avKIN3X4NMjL5H0lbYxynKoKvZi8hlhMNu36Fi5P0i9OGXkfA8vbB57C6TDcGxq9g2jIvx0dmSU9W14Z6IFE1E2FAeuLAdZlFs0nB6kWgnZ8kYJarpOFdNk3AyT0L6a4qAJCEjfoBd7p+eUrFqEP38XaXFXtTXTxllhpUvUhNAD5Dwsp2lN907XU6GZoafeGNihk+YaqaC6moKNYy4fzOUMoU7GpC88lNARE57WrGLsCXrUJmxJ5U631HF3PH9pEMFqKNe6y4cXxJmMurm+jxgRd64RCJN9BDuw8OW841gYMTggY01C00zr4W9zDawHNCq+C8dT5LLTnrWWZ+Chph26tOHxCsjQbjqa5el5hk="
 
 cache:
-  directories:
-    - node_modules
-    # work around https://github.com/travis-ci/travis-yaml/issues/111
-    - ${YARN_CACHE_FOLDER}
+  yarn: true
 
 before_install:
-  # https://yarnpkg.com/en/docs/install-ci#travis-tab
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
-  - export PATH=$HOME/.yarn/bin:$PATH
-  - if [[ $(yarn --version) != $YARN_VERSION ]]; then
-      echo "WARNING unexpected yarn version";
-      which -a yarn;
-      yarn --version;
-    fi
+  # https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Travis-CI-supports-yarn
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
+  - export PATH="$HOME/.yarn/bin:$PATH"
 
 script:
   - yarn test
-

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -3,20 +3,8 @@
 const gulp = require('gulp');
 const runSequence = require('run-sequence');
 const gulpLoadPlugins = require('gulp-load-plugins');
-const map = require('map-stream');
 
 const plugins = gulpLoadPlugins();
-
-// ----------------------------- GitHub Statuses ------------------------------
-import { Repository, Statuses, StatusOptions } from 'commit-status-reporter';
-const githubRepository = new Repository(
-  'uProxy',
-  'ShadowsocksConfig',
-  plugins.util.env.GITHUB_TOKEN,
-);
-console.log('Reporting on commit:', plugins.util.env.COMMIT);
-const githubCommit = githubRepository.commit(plugins.util.env.COMMIT);
-// ----------------------------------------------------------------------------
 
 const moduleCompatibilityHeader = `(function iife() {
   const platformExportObj = (function detectPlatformExportObj() {
@@ -70,34 +58,6 @@ gulp.task('build:tests', () => {
     })
     .js
     .pipe(gulp.dest('.'));
-});
-
-
-gulp.task('tslint', () => {
-  let errorCount = 0;
-  const status = githubCommit.getStatus('TypeScript Code Style');
-  return status.report(Statuses.pending)
-    .then(() => {
-      return gulp.src('shadowsocks_config.ts')
-        .pipe(plugins.tslint({
-          configuration: 'tslint.json',
-          formatter: 'prose'
-        }))
-        .pipe(map((file, done) => {
-          errorCount += file.tslint.errorCount;
-          done(null, file);
-        }))
-        .pipe(plugins.tslint.report({
-          emitError: false
-        }));
-    })
-    .then(() => {
-      const hasErrors = (errorCount > 0);
-      const state = hasErrors ? Statuses.failure : Statuses.success;
-      const description = hasErrors ? `failed with ${errorCount} errors` : '';
-      return status.report(state, description);
-    });
-
 });
 
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "postinstall": "tsc -t ES6 -m commonjs Gulpfile.ts",
     "build": "gulp",
     "test": "gulp && jasmine --config=jasmine.json",
+    "precommit": "tslint -p . --fix; git-clang-format",
     "clean": "rm -rf node_modules/ Gulpfile.js *.spec.js"
   },
   "devDependencies": {
@@ -13,6 +14,7 @@
     "@types/gulp": "^4.0.4",
     "@types/jasmine": "^2.8.6",
     "@types/node": "^8.0.41",
+    "clang-format": "^1.2.2",
     "commit-status-reporter": "^0.0.5",
     "gulp": "^3.9.1",
     "gulp-cli": "^1.4.0",
@@ -21,11 +23,10 @@
     "gulp-load-plugins": "^1.5.0",
     "gulp-replace": "^0.6.1",
     "gulp-sourcemaps": "^2.6.1",
-    "gulp-tslint": "^8.1.2",
     "gulp-typescript": "^3.2.2",
     "gulp-util": "^3.0.8",
+    "husky": "^0.14.3",
     "jasmine": "^3.1.0",
-    "map-stream": "^0.0.7",
     "run-sequence": "^2.2.0",
     "tslib": "^1.8.0",
     "typescript": "^2.5.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,6 @@
     "declaration": false,
     "sourceMap": false,
     "inlineSourceMap": false,
-    "listFiles": true,
-    "traceResolution": true,
     "pretty": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,6 +148,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+async@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
@@ -210,6 +214,18 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
+clang-format@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.2.tgz#a7277a03fce9aa4e387ddaa83b60d99dab115737"
+  dependencies:
+    async "^1.5.2"
+    glob "^7.0.0"
+    resolve "^1.1.6"
 
 cliui@^3.0.3:
   version "3.2.0"
@@ -642,7 +658,7 @@ glob@^5.0.3, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.6, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.6, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -793,14 +809,6 @@ gulp-sourcemaps@^2.6.1:
     through2 "2.X"
     vinyl "1.X"
 
-gulp-tslint@^8.1.2:
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.2.tgz#e0f43194b473d7e76bb45a58fe8c60e7dfe3beb2"
-  dependencies:
-    gulp-util "~3.0.8"
-    map-stream "~0.0.7"
-    through "~2.3.8"
-
 gulp-typescript@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-3.2.2.tgz#b7e5e1d3cb35f772e53e604026601826e2be77fc"
@@ -810,7 +818,7 @@ gulp-typescript@^3.2.2:
     through2 "~2.0.1"
     vinyl-fs "~2.4.3"
 
-gulp-util@^3.0.0, gulp-util@^3.0.8, gulp-util@~3.0.7, gulp-util@~3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.8, gulp-util@~3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -887,6 +895,14 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -928,6 +944,12 @@ is-absolute@^0.2.3:
 is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -1252,10 +1274,6 @@ map-cache@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
 
-map-stream@^0.0.7, map-stream@~0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
-
 matchdep@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/matchdep/-/matchdep-1.0.1.tgz#a57a33804491fbae208aba8f68380437abc2dca5"
@@ -1364,6 +1382,10 @@ netrc@^0.1.4:
 next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
@@ -1747,6 +1769,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -1782,10 +1808,6 @@ through2@^0.6.0, through2@^0.6.1:
   dependencies:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
-
-through@~2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 tildify@^1.0.0, tildify@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
Again, trying to make this more like our other repos:
* add clang-format config
* replace `gulp tslint` with a Husky pre-commit
* remove the custom Github statuses stuff